### PR TITLE
fixes for 1.41 grpc semantic conventions

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -419,8 +419,8 @@ internal class HttpInListener : ListenerHandler
 
             if (validStatusCode)
             {
-                // setting rpc.grpc.status_code
-                activity.SetTag(SemanticConventions.AttributeRpcGrpcStatusCode, grpcStatusCode);
+                // setting rpc.response.status_code
+                activity.SetTag(SemanticConventions.AttributeRpcResponseStatusCode, GrpcTagHelper.ConvertStatusCodeToString(grpcStatusCode));
             }
         }
     }

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -391,7 +391,7 @@ internal class HttpInListener : ListenerHandler
         // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/rpc/rpc-spans.md#span-name
         activity.DisplayName = details.DisplayName;
 
-        activity.SetTag(SemanticConventions.AttributeRpcSystem, GrpcTagHelper.RpcSystemGrpc);
+        activity.SetTag(SemanticConventions.AttributeRpcSystemName, GrpcTagHelper.RpcSystemGrpc);
 
         // see the spec https://github.com/open-telemetry/semantic-conventions/blob/v1.23.0/docs/rpc/rpc-spans.md
 
@@ -409,8 +409,7 @@ internal class HttpInListener : ListenerHandler
 
         if (details.IsParsed)
         {
-            activity.SetTag(SemanticConventions.AttributeRpcService, details.RpcService);
-            activity.SetTag(SemanticConventions.AttributeRpcMethod, details.RpcMethod);
+            activity.SetTag(SemanticConventions.AttributeRpcMethod, details.DisplayName);
 
             // Remove the grpc.method tag added by the gRPC .NET library
             activity.SetTag(GrpcTagHelper.GrpcMethodTagName, null);

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/OpenTelemetry.Instrumentation.GrpcCore.csproj
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/OpenTelemetry.Instrumentation.GrpcCore.csproj
@@ -24,9 +24,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(RepoRoot)\src\Shared\ActivityHelperExtensions.cs" Link="Includes\ActivityHelperExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\ActivitySourceFactory.cs" Link="Includes\ActivitySourceFactory.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\AssemblyVersionExtensions.cs" Link="Includes\AssemblyVersionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\GrpcStatusCanonicalCode.cs" Link="Includes\GrpcStatusCanonicalCode.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\GrpcTagHelper.cs" Link="Includes\GrpcTagHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />
   </ItemGroup>
 

--- a/src/OpenTelemetry.Instrumentation.GrpcCore/RpcScope.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcCore/RpcScope.cs
@@ -216,7 +216,7 @@ internal abstract class RpcScope<TRequest, TResponse> : IDisposable
             return;
         }
 
-        this.activity.SetTag(SemanticConventions.AttributeRpcResponseStatusCode, statusCode);
+        this.activity.SetTag(SemanticConventions.AttributeRpcResponseStatusCode, GrpcTagHelper.ConvertStatusCodeToString(statusCode));
         this.activity.Stop();
     }
 

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
@@ -176,7 +176,7 @@ internal sealed class GrpcClientDiagnosticListener : ListenerHandler
                 activity.SetStatus(GrpcTagHelper.ResolveSpanStatusForGrpcStatusCodeOnClient(status));
             }
 
-            activity.SetTag(SemanticConventions.AttributeRpcResponseStatusCode, status);
+            activity.SetTag(SemanticConventions.AttributeRpcResponseStatusCode, GrpcTagHelper.ConvertStatusCodeToString(status));
         }
 
         // Remove the grpc.status_code tag added by the gRPC .NET library

--- a/src/Shared/GrpcTagHelper.cs
+++ b/src/Shared/GrpcTagHelper.cs
@@ -27,6 +27,31 @@ internal static class GrpcTagHelper
                int.TryParse(grpcStatusCodeTag as string, NumberStyles.None, CultureInfo.InvariantCulture, out statusCode);
     }
 
+    public static string ConvertStatusCodeToString(int statusCode)
+    {
+        return (GrpcStatusCanonicalCode)statusCode switch
+        {
+            GrpcStatusCanonicalCode.Ok => "OK",
+            GrpcStatusCanonicalCode.Cancelled => "CANCELLED",
+            GrpcStatusCanonicalCode.Unknown => "UNKNOWN",
+            GrpcStatusCanonicalCode.InvalidArgument => "INVALID_ARGUMENT",
+            GrpcStatusCanonicalCode.DeadlineExceeded => "DEADLINE_EXCEEDED",
+            GrpcStatusCanonicalCode.NotFound => "NOT_FOUND",
+            GrpcStatusCanonicalCode.AlreadyExists => "ALREADY_EXISTS",
+            GrpcStatusCanonicalCode.PermissionDenied => "PERMISSION_DENIED",
+            GrpcStatusCanonicalCode.ResourceExhausted => "RESOURCE_EXHAUSTED",
+            GrpcStatusCanonicalCode.FailedPrecondition => "FAILED_PRECONDITION",
+            GrpcStatusCanonicalCode.Aborted => "ABORTED",
+            GrpcStatusCanonicalCode.OutOfRange => "OUT_OF_RANGE",
+            GrpcStatusCanonicalCode.Unimplemented => "UNIMPLEMENTED",
+            GrpcStatusCanonicalCode.Internal => "INTERNAL",
+            GrpcStatusCanonicalCode.Unavailable => "UNAVAILABLE",
+            GrpcStatusCanonicalCode.DataLoss => "DATA_LOSS",
+            GrpcStatusCanonicalCode.Unauthenticated => "UNAUTHENTICATED",
+            _ => "UNKNOWN",
+        };
+    }
+
     public static bool TryParseRpcServiceAndRpcMethod(string grpcMethod, out string rpcService, out string rpcMethod)
     {
         var span = grpcMethod.AsSpan();

--- a/test/OpenTelemetry.Contrib.Shared.Tests/GrpcTagHelperTests.cs
+++ b/test/OpenTelemetry.Contrib.Shared.Tests/GrpcTagHelperTests.cs
@@ -45,10 +45,10 @@ public class GrpcTagHelperTests
         Assert.True(validConversion);
 
         var statusCode = GrpcTagHelper.ResolveSpanStatusForGrpcStatusCodeOnClient(status);
-        activity.SetTag(SemanticConventions.AttributeRpcGrpcStatusCode, status);
+        activity.SetTag(SemanticConventions.AttributeRpcResponseStatusCode, GrpcTagHelper.ConvertStatusCodeToString(status));
 
         Assert.Equal(ActivityStatusCode.Unset, statusCode);
-        Assert.Equal(status, activity.GetTagValue(SemanticConventions.AttributeRpcGrpcStatusCode));
+        Assert.Equal(GrpcTagHelper.ConvertStatusCodeToString(status), activity.GetTagValue(SemanticConventions.AttributeRpcResponseStatusCode));
     }
 
     [Theory]
@@ -103,6 +103,32 @@ public class GrpcTagHelperTests
         Assert.Equal(expectedActivityStatusCode, result);
     }
 
+    [Theory]
+    [InlineData(0, "OK")] // Ok
+    [InlineData(-1, "UNKNOWN")] // Invalid negative status code
+    [InlineData(1, "CANCELLED")] // Cancelled
+    [InlineData(2, "UNKNOWN")] // Unknown
+    [InlineData(3, "INVALID_ARGUMENT")] // InvalidArgument
+    [InlineData(4, "DEADLINE_EXCEEDED")] // DeadlineExceeded
+    [InlineData(5, "NOT_FOUND")] // NotFound
+    [InlineData(6, "ALREADY_EXISTS")] // AlreadyExists
+    [InlineData(7, "PERMISSION_DENIED")] // PermissionDenied
+    [InlineData(8, "RESOURCE_EXHAUSTED")] // ResourceExhausted
+    [InlineData(9, "FAILED_PRECONDITION")] // FailedPrecondition
+    [InlineData(10, "ABORTED")] // Aborted
+    [InlineData(11, "OUT_OF_RANGE")] // OutOfRange
+    [InlineData(12, "UNIMPLEMENTED")] // Unimplemented
+    [InlineData(13, "INTERNAL")] // Internal
+    [InlineData(14, "UNAVAILABLE")] // Unavailable
+    [InlineData(15, "DATA_LOSS")] // DataLoss
+    [InlineData(16, "UNAUTHENTICATED")] // Unauthenticated
+    [InlineData(99, "UNKNOWN")] // Unknown status code
+    public void GrpcTagHelper_ConvertStatusCodeToString(int grpcStatusCode, string expectedStatusCode)
+    {
+        var result = GrpcTagHelper.ConvertStatusCodeToString(grpcStatusCode);
+        Assert.Equal(expectedStatusCode, result);
+    }
+
     [Fact]
     public void GrpcTagHelper_GetGrpcStatusCodeFromEmptyActivity()
     {
@@ -111,6 +137,6 @@ public class GrpcTagHelperTests
         var validConversion = GrpcTagHelper.TryGetGrpcStatusCodeFromActivity(activity, out var status);
         Assert.False(validConversion);
         Assert.Equal(-1, status);
-        Assert.Null(activity.GetTagValue(SemanticConventions.AttributeRpcGrpcStatusCode));
+        Assert.Null(activity.GetTagValue(SemanticConventions.AttributeRpcResponseStatusCode));
     }
 }

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/GrpcTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/GrpcTests.cs
@@ -32,9 +32,9 @@ public class GrpcTests
         AssertTag(activity, SemanticConventions.AttributeClientPort, 4317);
         AssertTag(activity, SemanticConventions.AttributeHttpResponseStatusCode, 200);
         AssertTag(activity, SemanticConventions.AttributeRpcGrpcStatusCode, 13);
-        AssertTag(activity, SemanticConventions.AttributeRpcMethod, "Method");
-        AssertTag(activity, SemanticConventions.AttributeRpcService, "package.Service");
-        AssertTag(activity, SemanticConventions.AttributeRpcSystem, "grpc");
+        AssertTag(activity, SemanticConventions.AttributeRpcMethod, "package.Service/Method");
+        AssertTag(activity, SemanticConventions.AttributeRpcService, null);
+        AssertTag(activity, SemanticConventions.AttributeRpcSystemName, "grpc");
     }
 
     [Fact]
@@ -59,7 +59,7 @@ public class GrpcTests
         AssertTag(activity, SemanticConventions.AttributeRpcGrpcStatusCode, null);
         AssertTag(activity, SemanticConventions.AttributeRpcMethod, null);
         AssertTag(activity, SemanticConventions.AttributeRpcService, null);
-        AssertTag(activity, SemanticConventions.AttributeRpcSystem, "grpc");
+        AssertTag(activity, SemanticConventions.AttributeRpcSystemName, "grpc");
     }
 
     [Fact]
@@ -80,7 +80,7 @@ public class GrpcTests
         AssertTag(activity, GrpcTagHelper.GrpcMethodTagName, string.Empty);
         AssertTag(activity, GrpcTagHelper.GrpcStatusCodeTagName, "13");
         AssertTag(activity, SemanticConventions.AttributeRpcGrpcStatusCode, null);
-        AssertTag(activity, SemanticConventions.AttributeRpcSystem, null);
+        AssertTag(activity, SemanticConventions.AttributeRpcSystemName, null);
     }
 
     private static void AssertTag(Activity activity, string name, object? expected) =>

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/GrpcTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/GrpcTests.cs
@@ -31,7 +31,7 @@ public class GrpcTests
         AssertTag(activity, SemanticConventions.AttributeClientAddress, "127.0.0.1");
         AssertTag(activity, SemanticConventions.AttributeClientPort, 4317);
         AssertTag(activity, SemanticConventions.AttributeHttpResponseStatusCode, 200);
-        AssertTag(activity, SemanticConventions.AttributeRpcGrpcStatusCode, 13);
+        AssertTag(activity, SemanticConventions.AttributeRpcResponseStatusCode, "INTERNAL");
         AssertTag(activity, SemanticConventions.AttributeRpcMethod, "package.Service/Method");
         AssertTag(activity, SemanticConventions.AttributeRpcService, null);
         AssertTag(activity, SemanticConventions.AttributeRpcSystemName, "grpc");
@@ -56,7 +56,7 @@ public class GrpcTests
         AssertTag(activity, GrpcTagHelper.GrpcStatusCodeTagName, "invalid");
         AssertTag(activity, SemanticConventions.AttributeClientAddress, null);
         AssertTag(activity, SemanticConventions.AttributeClientPort, 4317);
-        AssertTag(activity, SemanticConventions.AttributeRpcGrpcStatusCode, null);
+        AssertTag(activity, SemanticConventions.AttributeRpcResponseStatusCode, null);
         AssertTag(activity, SemanticConventions.AttributeRpcMethod, null);
         AssertTag(activity, SemanticConventions.AttributeRpcService, null);
         AssertTag(activity, SemanticConventions.AttributeRpcSystemName, "grpc");
@@ -79,7 +79,7 @@ public class GrpcTests
 
         AssertTag(activity, GrpcTagHelper.GrpcMethodTagName, string.Empty);
         AssertTag(activity, GrpcTagHelper.GrpcStatusCodeTagName, "13");
-        AssertTag(activity, SemanticConventions.AttributeRpcGrpcStatusCode, null);
+        AssertTag(activity, SemanticConventions.AttributeRpcResponseStatusCode, null);
         AssertTag(activity, SemanticConventions.AttributeRpcSystemName, null);
     }
 

--- a/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcCore.Tests/GrpcCoreClientInterceptorTests.cs
@@ -344,6 +344,7 @@ public class GrpcCoreClientInterceptorTests
         Assert.True(activity.IsStopped, "The activity has not been stopped.");
 
         var expectedRpcMethod = $"OpenTelemetry.Instrumentation.GrpcCore.Tests.Foobar/{expectedMethodName}";
+        var expectedResponseStatusCode = GrpcTagHelper.ConvertStatusCodeToString((int)expectedStatusCode);
 
         Assert.Equal(expectedRpcMethod, activity.DisplayName);
 
@@ -352,7 +353,7 @@ public class GrpcCoreClientInterceptorTests
         Assert.Contains(activity.TagObjects, t => t.Key == SemanticConventions.AttributeRpcSystemName && (string?)t.Value == "grpc");
         Assert.DoesNotContain(activity.TagObjects, t => t.Key == SemanticConventions.AttributeRpcService);
         Assert.Contains(activity.TagObjects, t => t.Key == SemanticConventions.AttributeRpcMethod && (string?)t.Value == expectedRpcMethod);
-        Assert.Contains(activity.TagObjects, t => t.Key == SemanticConventions.AttributeRpcResponseStatusCode && (int?)t.Value == (int)expectedStatusCode);
+        Assert.Contains(activity.TagObjects, t => t.Key == SemanticConventions.AttributeRpcResponseStatusCode && (string?)t.Value == expectedResponseStatusCode);
 
         // Cancelled is not an error.
         if (expectedStatusCode is not StatusCode.OK and not StatusCode.Cancelled)

--- a/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.client.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.client.cs
@@ -90,7 +90,7 @@ public partial class GrpcTests
         // Tags added by the library then removed from the instrumentation
         Assert.Null(activity.GetTagValue(GrpcTagHelper.GrpcMethodTagName));
         Assert.Null(activity.GetTagValue(GrpcTagHelper.GrpcStatusCodeTagName));
-        Assert.Equal(0, activity.GetTagValue(SemanticConventions.AttributeRpcResponseStatusCode));
+        Assert.Equal("OK", activity.GetTagValue(SemanticConventions.AttributeRpcResponseStatusCode));
 
         if (shouldEnrich)
         {
@@ -146,7 +146,7 @@ public partial class GrpcTests
 
         ValidateGrpcActivity(grpcSpan);
         Assert.Equal($"greet.Greeter/SayHello", grpcSpan.DisplayName);
-        Assert.Equal(0, grpcSpan.GetTagValue(SemanticConventions.AttributeRpcResponseStatusCode));
+        Assert.Equal("OK", grpcSpan.GetTagValue(SemanticConventions.AttributeRpcResponseStatusCode));
         Assert.Equal("POST", httpSpan.DisplayName);
         Assert.Equal(grpcSpan.SpanId, httpSpan.ParentSpanId);
 
@@ -199,19 +199,19 @@ public partial class GrpcTests
 
         ValidateGrpcActivity(grpcSpan1);
         Assert.Equal($"greet.Greeter/SayHello", grpcSpan1.DisplayName);
-        Assert.Equal(0, grpcSpan1.GetTagValue(SemanticConventions.AttributeRpcResponseStatusCode));
+        Assert.Equal("OK", grpcSpan1.GetTagValue(SemanticConventions.AttributeRpcResponseStatusCode));
 
         ValidateGrpcActivity(grpcSpan2);
         Assert.Equal($"greet.Greeter/SayHello", grpcSpan2.DisplayName);
-        Assert.Equal(0, grpcSpan2.GetTagValue(SemanticConventions.AttributeRpcResponseStatusCode));
+        Assert.Equal("OK", grpcSpan2.GetTagValue(SemanticConventions.AttributeRpcResponseStatusCode));
 
         ValidateGrpcActivity(grpcSpan3);
         Assert.Equal($"greet.Greeter/SayHello", grpcSpan3.DisplayName);
-        Assert.Equal(0, grpcSpan3.GetTagValue(SemanticConventions.AttributeRpcResponseStatusCode));
+        Assert.Equal("OK", grpcSpan3.GetTagValue(SemanticConventions.AttributeRpcResponseStatusCode));
 
         ValidateGrpcActivity(grpcSpan4);
         Assert.Equal($"greet.Greeter/SayHello", grpcSpan4.DisplayName);
-        Assert.Equal(0, grpcSpan4.GetTagValue(SemanticConventions.AttributeRpcResponseStatusCode));
+        Assert.Equal("OK", grpcSpan4.GetTagValue(SemanticConventions.AttributeRpcResponseStatusCode));
     }
 
 #if NET
@@ -267,7 +267,7 @@ public partial class GrpcTests
             Assert.Equal($"POST /greet.Greeter/SayHello", serverActivity.DisplayName);
             Assert.Equal(clientActivity.TraceId, serverActivity.TraceId);
             Assert.Equal(clientActivity.SpanId, serverActivity.ParentSpanId);
-            Assert.Equal(0, clientActivity.GetTagValue(SemanticConventions.AttributeRpcGrpcStatusCode));
+            Assert.Equal("OK", clientActivity.GetTagValue(SemanticConventions.AttributeRpcResponseStatusCode));
             Assert.Equal("customValue", serverActivity.GetCustomProperty("customField") as string);
         }
         finally

--- a/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.server.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.server.cs
@@ -76,9 +76,10 @@ public partial class GrpcTests : IAsyncLifetime
 
         if (enableGrpcAspNetCoreSupport != null && enableGrpcAspNetCoreSupport.Equals("true", StringComparison.OrdinalIgnoreCase))
         {
-            Assert.Equal("grpc", activity.GetTagValue(SemanticConventions.AttributeRpcSystem));
-            Assert.Equal("greet.Greeter", activity.GetTagValue(SemanticConventions.AttributeRpcService));
-            Assert.Equal("SayHello", activity.GetTagValue(SemanticConventions.AttributeRpcMethod));
+            Assert.Equal("greet.Greeter/SayHello", activity.DisplayName);
+            Assert.Equal("grpc", activity.GetTagValue(SemanticConventions.AttributeRpcSystemName));
+            Assert.Null(activity.GetTagValue(SemanticConventions.AttributeRpcService));
+            Assert.Equal("greet.Greeter/SayHello", activity.GetTagValue(SemanticConventions.AttributeRpcMethod));
             Assert.Contains(activity.GetTagValue(SemanticConventions.AttributeClientAddress), clientLoopbackAddresses);
             Assert.NotEqual(0, activity.GetTagValue(SemanticConventions.AttributeClientPort));
             Assert.Null(activity.GetTagValue(GrpcTagHelper.GrpcMethodTagName));
@@ -87,6 +88,7 @@ public partial class GrpcTests : IAsyncLifetime
         }
         else
         {
+            Assert.Equal("POST /greet.Greeter/SayHello", activity.DisplayName);
             Assert.NotNull(activity.GetTagValue(GrpcTagHelper.GrpcMethodTagName));
             Assert.NotNull(activity.GetTagValue(GrpcTagHelper.GrpcStatusCodeTagName));
         }
@@ -154,9 +156,10 @@ public partial class GrpcTests : IAsyncLifetime
 
             if (enableGrpcAspNetCoreSupport != null && enableGrpcAspNetCoreSupport.Equals("true", StringComparison.OrdinalIgnoreCase))
             {
+                Assert.Equal("greet.Greeter/SayHello", activity.DisplayName);
                 Assert.Equal("grpc", activity.GetTagValue(SemanticConventions.AttributeRpcSystemName));
-                Assert.Equal("greet.Greeter", activity.GetTagValue(SemanticConventions.AttributeRpcService));
-                Assert.Equal("SayHello", activity.GetTagValue(SemanticConventions.AttributeRpcMethod));
+                Assert.Null(activity.GetTagValue(SemanticConventions.AttributeRpcService));
+                Assert.Equal("greet.Greeter/SayHello", activity.GetTagValue(SemanticConventions.AttributeRpcMethod));
                 Assert.Contains(activity.GetTagValue(SemanticConventions.AttributeNetPeerIp), clientLoopbackAddresses);
                 Assert.NotEqual(0, activity.GetTagValue(SemanticConventions.AttributeNetPeerPort));
                 Assert.Null(activity.GetTagValue(GrpcTagHelper.GrpcMethodTagName));
@@ -165,6 +168,7 @@ public partial class GrpcTests : IAsyncLifetime
             }
             else
             {
+                Assert.Equal("POST /greet.Greeter/SayHello", activity.DisplayName);
                 Assert.NotNull(activity.GetTagValue(GrpcTagHelper.GrpcMethodTagName));
                 Assert.NotNull(activity.GetTagValue(GrpcTagHelper.GrpcStatusCodeTagName));
             }

--- a/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.server.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/GrpcTests.server.cs
@@ -84,7 +84,7 @@ public partial class GrpcTests : IAsyncLifetime
             Assert.NotEqual(0, activity.GetTagValue(SemanticConventions.AttributeClientPort));
             Assert.Null(activity.GetTagValue(GrpcTagHelper.GrpcMethodTagName));
             Assert.Null(activity.GetTagValue(GrpcTagHelper.GrpcStatusCodeTagName));
-            Assert.Equal(0, activity.GetTagValue(SemanticConventions.AttributeRpcGrpcStatusCode));
+            Assert.Equal("OK", activity.GetTagValue(SemanticConventions.AttributeRpcResponseStatusCode));
         }
         else
         {
@@ -164,7 +164,7 @@ public partial class GrpcTests : IAsyncLifetime
                 Assert.NotEqual(0, activity.GetTagValue(SemanticConventions.AttributeNetPeerPort));
                 Assert.Null(activity.GetTagValue(GrpcTagHelper.GrpcMethodTagName));
                 Assert.Null(activity.GetTagValue(GrpcTagHelper.GrpcStatusCodeTagName));
-                Assert.Equal(0, activity.GetTagValue(SemanticConventions.AttributeRpcResponseStatusCode));
+                Assert.Equal("OK", activity.GetTagValue(SemanticConventions.AttributeRpcResponseStatusCode));
             }
             else
             {

--- a/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/OpenTelemetry.Instrumentation.GrpcNetClient.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.GrpcNetClient.Tests/OpenTelemetry.Instrumentation.GrpcNetClient.Tests.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="OpenTelemetry.Api" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" />
     <PackageReference Include="OpenTelemetry.Extensions.Propagators" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Condition="'$([MSBuild]::GetTargetFrameworkIdentifier(`$(TargetFramework)`))' == '.NETCoreApp'" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
   </ItemGroup>
 
@@ -28,6 +27,7 @@
 
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.GrpcNetClient\OpenTelemetry.Instrumentation.GrpcNetClient.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.AspNetCore\OpenTelemetry.Instrumentation.AspNetCore.csproj" Condition="'$([MSBuild]::GetTargetFrameworkIdentifier(`$(TargetFramework)`))' == '.NETCoreApp'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
fixes in HttpInListener:
-  remove rpc.service and update rpc.method
-  use rpc.system.name instead of rpc.system

fixes in all grpc instrumentation: rpc.response.status_code should have string representation https://opentelemetry.io/docs/specs/semconv/rpc/grpc/